### PR TITLE
Add benchmark results processing and deployment

### DIFF
--- a/.github/workflows/process-results.yml
+++ b/.github/workflows/process-results.yml
@@ -1,0 +1,40 @@
+name: Process benchmark results
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  run-benchmark-monitor:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout processing script
+      uses: actions/checkout@v3
+      with:
+        repository: cz4rs/benchmark_monitor
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        path: benchmark-results
+
+    - name: Process available benchmark results
+      run: |-
+        pip3 install -r requirements.txt
+        python3 benchmark_monitor.py -d ./benchmark-results -o output
+
+    - name: Generate nojekyll file
+      working-directory: output
+      run: touch .nojekyll
+
+    - name: Deploy
+      if: ${{ github.ref == 'refs/heads/main' }}
+      uses: JamesIves/github-pages-deploy-action@v4
+      with:
+        folder: output
+        branch: deploy-benchmarks
+        clean: true
+        single-commit: true
+

--- a/.github/workflows/process-results.yml
+++ b/.github/workflows/process-results.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Process available benchmark results
       run: |-
         pip3 install -r requirements.txt
-        python3 benchmark_monitor.py -d ./benchmark-results -o output
+        python3 benchmark_monitor.py -s 50 -d ./benchmark-results -o output
 
     - name: Generate nojekyll file
       working-directory: output

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # kokkos-benchmark-results
+
+Repository for storing performance benchmark results.
+
+## Generate performance graphs locally
+```
+git clone git@github.com:kokkos/benchmark_monitor.git
+git clone git@github.com:kokkos/kokkos-benchmark-results.git
+cd benchmark_monitor
+
+python3 -m venv env
+source env/bin/activate
+pip install -r requirements.txt
+python benchmark_monitor.py -d ../benchmark-results -o output
+```
+This will generate `index.html` and the rest of files in `output` diectory.

--- a/README.md
+++ b/README.md
@@ -3,13 +3,15 @@
 Repository for storing performance benchmark results.
 
 ## Generate performance graphs locally
-```
+```sh
+# get benchmark results and processing script
 git clone git@github.com:kokkos/benchmark_monitor.git
 git clone git@github.com:kokkos/kokkos-benchmark-results.git
 cd benchmark_monitor
-
+# create and activate virtual environment
 python3 -m venv env
 source env/bin/activate
+# continue inside a virtual environment
 pip install -r requirements.txt
 python benchmark_monitor.py -d ../benchmark-results -o output
 ```


### PR DESCRIPTION
fixes https://github.com/kokkos/kokkos/issues/5464

Process benchmark results and deploy generated pages.
Deployment targets `deploy-benchmarks` branch of this repository and should make the webpage appear at https://kokkos.github.io/kokkos-benchmark-results/.

- repository settings to enable GitHub pages deployment:

![image](https://user-images.githubusercontent.com/4639165/211854812-bf0df7e9-8f0e-4695-b91c-e945873ac061.png)

- for convenience: [enable running workflows on pull requests from forks](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#configuring-the-fork-policy-for-a-private-repository) (for this repository)
- live demo: https://cz4rs.github.io/kokkos-benchmark-results/